### PR TITLE
fix: [1122][Hyperion] Imports got deleted

### DIFF
--- a/controllers/installer_controller.go
+++ b/controllers/installer_controller.go
@@ -28,6 +28,8 @@ import (
 	"github.com/devtron-labs/inception/pkg/language"
 	parser2 "github.com/devtron-labs/inception/pkg/language/parser"
 	"github.com/go-logr/logr"
+	"github.com/patrickmn/go-cache"
+	"github.com/posthog/posthog-go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"io"


### PR DESCRIPTION
Adding Devtron mode to PostHog events so that we can understand users and their usage

Issue: Payload events doesn't have Devtron mode

Cause: imports got deleted by mistake

Countermeasure: Added imports back